### PR TITLE
Exclude Info.plist for targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,14 @@ let package = Package(
     targets: [
         .target(
             name: "ModernRIBs",
-            path: "ModernRIBs"
+            path: "ModernRIBs",
+            exclude: ["Info.plist"]
         ),
         .testTarget(
             name: "ModernRIBsTests",
             dependencies: ["ModernRIBs"],
-            path: "ModernRIBsTests"
+            path: "ModernRIBsTests",
+            exclude: ["Info.plist"]
         ),
     ]
 )


### PR DESCRIPTION
리소스 번들링을 지원하는 최신 SPM 버전을 사용하면 워닝이 뜹니다.
워닝을 없애는 PR입니다.